### PR TITLE
Prevent key press from escaping mathlive and use local assets instead of network's

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "main": false
   },
   "scripts": {
-    "build": "rm -R dist && echo 'dist folder removed' ; parcel build --no-source-maps src/index.html --public-url ./"
+    "build": "rm -R dist && echo 'dist folder removed' ; parcel build --no-source-maps src/index.html --public-url ./ ; cp node_modules/mathlive/dist/mathlive.min.js dist/"
   },
   "keywords": [],
   "author": "hkgnp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function main() {
 			margin: 0px;
 			box-shadow: 0 0 15px rgba(0, 0, 0, .2);
 		}
-											`);
+	`);
 
   // Generate unique identifier
   const uniqueIdentifier = () =>

--- a/src/renderMathLive.ts
+++ b/src/renderMathLive.ts
@@ -13,10 +13,10 @@ export default function renderMathLive(id: string) {
     constructor() {
       super();
       logseq.provideStyle(`
-													#block-content-${this.uuid} .block-properties {
-														display: none !important;
-													}
-													`);
+        #block-content-${this.uuid} .block-properties {
+          display: none !important;
+        }
+      `);
     }
 
     static get observedAttributes() {
@@ -36,6 +36,10 @@ export default function renderMathLive(id: string) {
       this.addEventListener("mousedown", function (e: any) {
         e.stopPropagation();
         e.preventDefault();
+      });
+      // Set event listener to prevent keythrough on div
+      this.addEventListener("keydown", function (e: any) {
+        e.stopPropagation();
       });
 
       this.render();
@@ -80,10 +84,7 @@ export default function renderMathLive(id: string) {
       extends: "div",
     });
     const script = top?.document.createElement("script");
-    script?.setAttribute(
-      "src",
-      "https://unpkg.com/mathlive/dist/mathlive.min.js"
-    );
+    script?.setAttribute("src", `${logseq.baseInfo.lsr}dist/mathlive.min.js`);
     top?.document.body.appendChild(script as HTMLScriptElement);
   }
 }


### PR DESCRIPTION
This PR contains 2 changes:

1. Prevent key presses from escaping MathLive so the won't affect Logseq's normal operations.
2. Use bundled assets instead of network's.